### PR TITLE
Update workshop kids to add clarity on ages

### DIFF
--- a/src/app/common/mocks/agendaThreeC.ts
+++ b/src/app/common/mocks/agendaThreeC.ts
@@ -11,7 +11,7 @@ export const AGENDATHREE_C = [
   },
   {
     session: 'Kids Workshop',
-    speaker: 'Workshops for kids 4/7 and 8/12',
+    speaker: 'Lego Maze for kids 4-7 and Do-it-Yourself Robots for kids 8-12',
     time: '16:00 - 17:30',
     room: 'ManoMano',
     lang: 'Español',


### PR DESCRIPTION
I just changed the title of the workshop and changed age format to use '-' character instead of '/' character.